### PR TITLE
Fix typo in simple example

### DIFF
--- a/simple example.ipynb
+++ b/simple example.ipynb
@@ -202,7 +202,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "Obviously you can also direcyly used those defined in [numpy](http://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.norm.html)."
+      "Obviously you can also directly use those defined in [numpy](http://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.norm.html)."
      ]
     },
     {


### PR DESCRIPTION
Hello! Many thanks for this library!
I found a typo while reading the docs; here's a fix.
