### PR TITLE
Added fastdtw

### DIFF
--- a/dtw.py
+++ b/dtw.py
@@ -1,4 +1,5 @@
-from numpy import array, zeros, argmin, inf
+from numpy import array, zeros, argmin, inf, equal
+from scipy.spatial.distance import cdist
 
 def dtw(x, y, dist):
     """
@@ -20,6 +21,38 @@ def dtw(x, y, dist):
     for i in range(r):
         for j in range(c):
             D1[i, j] = dist(x[i], y[j])
+    C = D1.copy()
+    for i in range(r):
+        for j in range(c):
+            D1[i, j] += min(D0[i, j], D0[i, j+1], D0[i+1, j])
+    if len(x)==1:
+        path = zeros(len(y)), range(len(y))
+    elif len(y) == 1:
+        path = range(len(x)), zeros(len(x))
+    else:
+        path = _traceback(D0)
+    return D1[-1, -1] / sum(D1.shape), C, D1, path
+
+def fastdtw(x, y, dist):
+    """
+    Computes Dynamic Time Warping (DTW) of two sequences in a faster way.
+    Instead of iterating through each element and calculating each distance,
+    this uses the cdist function from scipy (https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)
+
+    :param array x: N1*M array
+    :param array y: N2*M array
+    :param string or func dist: distance parameter for cdist. When string is given, cdist uses optimized functions for the distance metrics.
+    If a string is passed, the distance function can be 'braycurtis', 'canberra', 'chebyshev', 'cityblock', 'correlation', 'cosine', 'dice', 'euclidean', 'hamming', 'jaccard', 'kulsinski', 'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath', 'sqeuclidean', 'wminkowski', 'yule'.
+    Returns the minimum distance, the cost matrix, the accumulated cost matrix, and the wrap path.
+    """
+    assert len(x)
+    assert len(y)
+    r, c = len(x), len(y)
+    D0 = zeros((r + 1, c + 1))
+    D0[0, 1:] = inf
+    D0[1:, 0] = inf
+    D1 = D0[1:, 1:]
+    D0[1:,1:] = cdist(x,y,dist)
     C = D1.copy()
     for i in range(r):
         for j in range(c):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='dtw',
       url='https://github.com/pierre-rouanet/dtw',
       license='GNU GENERAL PUBLIC LICENSE Version 3',
 
-      install_requires=['numpy'],
+      install_requires=['numpy', 'scipy'],
       setup_requires=['setuptools_git >= 0.3', ],
 
       py_modules=['dtw'],


### PR DESCRIPTION
Hi, I'm implementing a speech comparison back-end and i used your library. In my journey of developing my application, I found out that the speed for calculating the DTW between a large number of MFCC coefficients is slow (in the context of my application). For that reason, fastdtw was implemented, by making use of scipy's  [cdist](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html#Parameters) function which has optimised functions for calculating the distance between matrices.

This function supports giving the distance function as a parameter, or giving it as a string. If the latter is used, then cdist will be using an corresponding optimised function. Here below is a little code for time benchmarking purposes: 
```python
import numpy as np
from scipy.spatial.distance import cosine
from dtw import dtw, fastdtw
import timeit

x = np.random.rand(1000).reshape(-1,1)
y = np.random.rand(1000).reshape(-1,1)

start = timeit.default_timer()
fastdtw(x,y,cosine)
end = timeit.default_timer()
print ("DTW with scipy cosine distance:" ,end-start)
print "========"
start = timeit.default_timer()
fastdtw(x,y,'cosine')
end = timeit.default_timer()
print ("DTW with scipy cdist using cosine distance:",end-start)
```

And the output of this code in a I5-5gen with 8gb of ram is: 

```
('DTW with scipy cosine distance:', 47.640693556034876)
========
('DTW with scipy cdist using cosine distance:', 1.4689458024448427)
```
Also, thanks for sharing your code.
Sebastian