### PR TITLE
fix bugs in dtw function

### DIFF
--- a/dtw.py
+++ b/dtw.py
@@ -27,8 +27,8 @@ def dtw(x, y, dist, warp=1):
         for j in range(c):
             min_list = [D0[i, j]]
             for k in range(1, warp + 1):
-                i_k = min(i + k, r - 1)
-                j_k = min(j + k, c - 1)
+                i_k = min(i + k, r)
+                j_k = min(j + k, c)
                 min_list += [D0[i_k, j], D0[i, j_k]]
             D1[i, j] += min(min_list)
     if len(x)==1:


### PR DESCRIPTION
compare result with fastdtw(https://github.com/slaypni/fastdtw):

from scipy.spatial.distance import euclidean
from fastdtw import dtw

x = np.array([[1,1], [2,2], [3,3], [4,4], [5,5]])
y = np.array([[2,2], [3,3], [4,4]])
distance, path = dtw(x, y, dist=euclidean)

**The function _accelerated_dtw_ may have same problem.**