### PR TITLE
Fix difference in acc cost between normal and accelerated version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,9 @@ y = np.array([1, 1, 2, 4, 2, 1, 2, 0]).reshape(-1, 1)
 
 from dtw import dtw
 
-# Here, we use L2 norm as the element comparison distance
-l2_norm = lambda x, y: (x - y) ** 2
+euclidean_norm = lambda x, y: np.abs(x - y)
 
-d, cost_matrix, acc_cost_matrix, path = dtw(x, y, dist=l2_norm)
+d, cost_matrix, acc_cost_matrix, path = dtw(x, y, dist=euclidean_norm)
 
 print(d)
 >>> 0.1111111111111111 # Only the cost for the insertions is kept

--- a/dtw/dtw.py
+++ b/dtw/dtw.py
@@ -85,8 +85,8 @@ def accelerated_dtw(x, y, dist, warp=1):
         for j in range(c):
             min_list = [D0[i, j]]
             for k in range(1, warp + 1):
-                min_list += [D0[min(i + k, r - 1), j],
-                             D0[i, min(j + k, c - 1)]]
+                min_list += [D0[min(i + k, r), j],
+                             D0[i, min(j + k, c)]]
             D1[i, j] += min(min_list)
     if len(x) == 1:
         path = zeros(len(y)), range(len(y))

--- a/dtw/version.py
+++ b/dtw/version.py
@@ -1,1 +1,1 @@
-version = '1.3.2'
+version = '1.3.3'

--- a/tests/test_fastvsnormal.py
+++ b/tests/test_fastvsnormal.py
@@ -1,0 +1,50 @@
+import unittest
+import numpy as np
+
+from dtw import dtw, accelerated_dtw
+
+
+class FastVsNormalTestCase(unittest.TestCase):
+    def test_fast_vs_normal_1D(self):
+        x = np.random.rand(np.random.randint(2, 100))
+        y = np.random.rand(np.random.randint(2, 100))
+
+        d1, c1, acc1, p1 = dtw(x, y, dist=lambda x, y: np.abs((x - y)))
+        d2, c2, acc2, p2 = accelerated_dtw(x, y, 'euclidean')
+
+        self.assertAlmostEqual(d1, d2)
+        self.assertAlmostEqual((c1 - c2).sum(), 0)
+        self.assertAlmostEqual((acc1 - acc2).sum(), 0)
+        self.assertTrue((p1[0] == p2[0]).all())
+        self.assertTrue((p1[1] == p2[1]).all())
+
+    def test_fast_vs_normal_ND(self):
+        N = np.random.randint(2, 100)
+        m1 = np.random.randint(2, 100)
+        m2 = np.random.randint(2, 100)
+
+        x = np.random.rand(m1, N)
+        y = np.random.rand(m2, N)
+
+        d1, c1, acc1, p1 = dtw(x, y, dist=lambda x, y: np.linalg.norm((x - y)))
+        d2, c2, acc2, p2 = accelerated_dtw(x, y, 'euclidean')
+
+        self.assertAlmostEqual(d1, d2)
+        self.assertAlmostEqual((c1 - c2).sum(), 0)
+        self.assertAlmostEqual((acc1 - acc2).sum(), 0)
+        self.assertTrue((p1[0] == p2[0]).all())
+        self.assertTrue((p1[1] == p2[1]).all())
+
+    def test_specific_case(self):
+        x = np.array([1.0, 0.9, 1.2, 2.3, 3.8, 3.3, 4.2, 1.9, 0.5, 0.3, 0.3])
+        y = np.array([0.5, 1.0, 0.9, 1.2, 2.3, 3.8, 3.3, 4.2, 1.9, 0.5, 0.3])
+
+        euclidean = lambda x, y: np.abs((x - y))
+
+        d1, _, _, _ = accelerated_dtw(x, y, 'euclidean')
+        d2, _, _, _ = accelerated_dtw(x, y, dist=euclidean)
+        d3, _, _, _ = dtw(x, y, dist=euclidean)
+
+        self.assertAlmostEqual(d1, 0.022727272727272728)
+        self.assertAlmostEqual(d2, 0.022727272727272728)
+        self.assertAlmostEqual(d3, 0.022727272727272728)


### PR DESCRIPTION
Fix a difference in the accumulated cost matrix computation. The accelerated version used lower limits.
Add unit test to check if both versions give the same results.

Fix #34 