### PR TITLE
exclude tests directory from installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='dtw',
       url='https://github.com/pierre-rouanet/dtw',
       license='GNU GENERAL PUBLIC LICENSE Version 3',
 
-      packages=find_packages(),
+      packages=find_packages(exclude=["tests"]),
       install_requires=['numpy', 'scipy'],
 
       test_suite='tests',


### PR DESCRIPTION
Currently, the package tries to install the `tests` directory. This should be excluded from the installed files.

Related: https://github.com/hetznercloud/hcloud-python/pull/41, https://github.com/leshchenko1979/reretry/issues/8

More info: https://projects.gentoo.org/python/guide/qawarn.html#example-for-test-packages-installed-by-setuptools